### PR TITLE
Fix parse_xbrl return type hints

### DIFF
--- a/src/generate_fs.py
+++ b/src/generate_fs.py
@@ -18,7 +18,9 @@ def main() -> None:
     # zip を展開してパス辞書取得
     xbrl_paths = extract_xbrl_from_zips(outputs, extracted)
 
-    aggregated: list[list[str | None]] = []
+    aggregated: list[
+        tuple[str, str, str, str | None, str | None, str | None, str | None, str | None]
+    ] = []
 
     print("✅ 解析開始:")
     for zip_name, info in xbrl_paths.items():


### PR DESCRIPTION
## Summary
- update parse_xbrl's return type annotation to match actual tuple
- adjust aggregated data type in generate_fs

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_688bf47848948327b487e6dc4f28e937