### PR TITLE
refactor: rewrite comments and docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,9 @@ description = "EDINET downloader and XBRL parser powered by Arelle."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-  # Arelle 本体（2.37 系で互換を維持、パッチ更新は許容）
   "arelle-release>=2.37,<2.38",
-  # ネイティブ拡張は広めに（ホイールがある範囲）※ 6.x も可
   "lxml>=5.4,<7",
   "regex>=2025.7,<2026",
-  # 周辺
   "pandas>=2.3,<3",
   "openpyxl>=3.1,<4",
   "python-dateutil>=2.8,<3",
@@ -30,5 +27,4 @@ generate = "generate_fs:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-# src 直下の単体モジュールを配布対象に
 py-modules = ["arelle_tools", "edinet_tools", "generate_fs", "outputs", "save_xbrl"]

--- a/src/edinet_tools.py
+++ b/src/edinet_tools.py
@@ -1,64 +1,89 @@
-# src/edinet_tools.py
+"""Helpers for interacting with the EDINET API."""
 
 import datetime
 import json
-import os # os.path.join など、必要に応じて残す
+import os  # For os.path.join and similar utilities.
 import urllib.parse
 import urllib.request
 from typing import List, Dict, Union
 
-# 注意: APIキーの読み込み (load_dotenv, EDINET_API_KEY) は
-# このファイルではなく、メインのスクリプト (例: main_edinet_tool.py) で行います。
+# API keys (e.g., via load_dotenv) are expected to be loaded by the caller.
+
 
 def filter_by_codes(
     docs: List[Dict],
     edinet_codes: Union[List[str], str] = [],
-    doc_type_codes: Union[List[str], str] = []
+    doc_type_codes: Union[List[str], str] = [],
 ) -> List[Dict]:
-    """
-    EDINET コードと帳票種別コードで開示書類リストをフィルタリングします。
-    [1]
+    """Filter disclosure document metadata by EDINET and document type codes.
+
+    Args:
+        docs (List[Dict]): List of document metadata dictionaries.
+        edinet_codes (Union[List[str], str], optional): EDINET codes to keep.
+        doc_type_codes (Union[List[str], str], optional): Document type codes to
+            keep.
+
+    Returns:
+        List[Dict]: Filtered list of documents.
     """
     if len(edinet_codes) == 0:
-        # edinet_codesが指定されていない場合、全てのedinetCodeを対象とする
-        edinet_codes = [doc['edinetCode'] for doc in docs if 'edinetCode' in doc and doc['edinetCode'] is not None]
+        # If edinet_codes is empty, target all edinetCode values.
+        edinet_codes = [
+            doc["edinetCode"]
+            for doc in docs
+            if "edinetCode" in doc and doc["edinetCode"] is not None
+        ]
     elif isinstance(edinet_codes, str):
         edinet_codes = [edinet_codes]
 
     if len(doc_type_codes) == 0:
-        # doc_type_codesが指定されていない場合、全てのdocTypeCodeを対象とする
-        doc_type_codes = [doc['docTypeCode'] for doc in docs if 'docTypeCode' in doc and doc['docTypeCode'] is not None]
+        # If doc_type_codes is empty, target all docTypeCode values.
+        doc_type_codes = [
+            doc["docTypeCode"]
+            for doc in docs
+            if "docTypeCode" in doc and doc["docTypeCode"] is not None
+        ]
     elif isinstance(doc_type_codes, str):
         doc_type_codes = [doc_type_codes]
 
-    # フィルタリングされた書類のリストを返す
     return [
         doc
         for doc in docs
-        if doc.get('edinetCode') in edinet_codes and doc.get('docTypeCode') in doc_type_codes
+        if doc.get("edinetCode") in edinet_codes
+        and doc.get("docTypeCode") in doc_type_codes
     ]
 
-def disclosure_documents(date: Union[str, datetime.date], api_key: str, type: int = 2) -> Dict:
-    """
-    指定日の開示書類メタデータをEDINET APIから取得します。
-    [2, 3]
+
+def disclosure_documents(
+    date: Union[str, datetime.date], api_key: str, type: int = 2
+) -> Dict:
+    """Retrieve disclosure document metadata for a given date.
+
+    Args:
+        date (Union[str, datetime.date]): Target date.
+        api_key (str): EDINET API key.
+        type (int, optional): API type parameter; ``2`` retrieves metadata and
+            body. Defaults to ``2``.
+
+    Returns:
+        Dict: JSON response from the EDINET API.
     """
     if isinstance(date, str):
         try:
-            datetime.datetime.strptime(date, '%Y-%m-%d')
+            datetime.datetime.strptime(date, "%Y-%m-%d")
         except ValueError:
             raise ValueError("Invalid date string. Use format 'YYYY-MM-DD'")
         date_str = date
     elif isinstance(date, datetime.date):
-        date_str = date.strftime('%Y-%m-%d')
+        date_str = date.strftime("%Y-%m-%d")
     else:
         raise TypeError("Date must be a string ('YYYY-MM-DD') or datetime.date")
 
-    # EDINET 書類一覧APIのエンドポイントURL [3]
+    # Endpoint for EDINET document list API [3].
     url = "https://disclosure.edinet-fsa.go.jp/api/v2/documents.json"
     params = {
         "date": date_str,
-        "type": type,  # '2' でメタデータと本文を取得 [3]
+        "type": type,  # "2" retrieves metadata and body [3].
         "Subscription-Key": api_key,
     }
 
@@ -66,54 +91,76 @@ def disclosure_documents(date: Union[str, datetime.date], api_key: str, type: in
     full_url = f"{url}?{query_string}"
 
     with urllib.request.urlopen(full_url) as response:
-        return json.loads(response.read().decode('utf-8'))
+        return json.loads(response.read().decode("utf-8"))
+
 
 def get_document(doc_id: str, api_key: str) -> urllib.request.urlopen:
+    """Download the body of a document by its ID.
+
+    Args:
+        doc_id (str): Document ID.
+        api_key (str): EDINET API key.
+
+    Returns:
+        urllib.request.urlopen: Response object for the download.
     """
-    書類ID (doc_id) を指定して本文（ZIP/CSV等）を取得します。
-    [4, 5]
-    """
-    # EDINET 書類取得APIのエンドポイントURL [4]
-    url = f'https://api.edinet-fsa.go.jp/api/v2/documents/{doc_id}'
+    # Endpoint for EDINET document retrieval API [4].
+    url = f"https://api.edinet-fsa.go.jp/api/v2/documents/{doc_id}"
     params = {
-        "type": 1,  # '1': XBRL形式, '5': CSV形式
+        "type": 1,  # "1": XBRL format, "5": CSV format.
         "Subscription-Key": api_key,
     }
 
     query_string = urllib.parse.urlencode(params)
-    full_url = f'{url}?{query_string}'
+    full_url = f"{url}?{query_string}"
 
     return urllib.request.urlopen(full_url)
 
+
 def save_document(doc_res: urllib.request.urlopen, output_path: str) -> None:
+    """Save the downloaded content to a file.
+
+    Args:
+        doc_res (urllib.request.urlopen): Response object containing data.
+        output_path (str): Destination file path.
     """
-    ダウンロードした内容をファイルに保存します。
-    [6]
-    """
-    with open(output_path, 'wb') as file_out:
+    with open(output_path, "wb") as file_out:
         file_out.write(doc_res.read())
-    print(f'Saved: {output_path}')
+    print(f"Saved: {output_path}")
+
 
 def get_documents_for_date_range(
     start_date: datetime.date,
     end_date: datetime.date,
-    api_key: str, # APIキーを受け取る
+    api_key: str,
     edinet_codes: List[str] = [],
-    doc_type_codes: List[str] = []
+    doc_type_codes: List[str] = [],
 ) -> List[Dict]:
+    """Collect documents for a range of dates and filter by codes.
+
+    Args:
+        start_date (datetime.date): Start date.
+        end_date (datetime.date): End date.
+        api_key (str): EDINET API key.
+        edinet_codes (List[str], optional): EDINET codes to keep.
+        doc_type_codes (List[str], optional): Document type codes to keep.
+
+    Returns:
+        List[Dict]: Filtered list of document metadata.
     """
-    指定された日付範囲で開示書類を取得し、EDINETコードと書類種別コードでフィルタリングします。
-    [6]
-    """
-    matching_docs = []
+    matching_docs: List[Dict] = []
     current_date = start_date
 
     while current_date <= end_date:
-        # disclosure_documents関数にAPIキーを渡す
+        # Pass the API key to disclosure_documents.
         docs_res = disclosure_documents(date=current_date, api_key=api_key)
-        if docs_res.get('results'): # 'results' キーが存在し、かつ内容があるか確認
-            # filter_by_codesはAPIキーを必要としない
-            filtered_docs = filter_by_codes(docs_res['results'], edinet_codes, doc_type_codes)
+        if docs_res.get("results"):
+            # filter_by_codes does not require the API key.
+            filtered_docs = filter_by_codes(
+                docs_res["results"], edinet_codes, doc_type_codes
+            )
             matching_docs.extend(filtered_docs)
         current_date += datetime.timedelta(days=1)
+
     return matching_docs
+

--- a/src/generate_fs.py
+++ b/src/generate_fs.py
@@ -1,48 +1,60 @@
-# src/generate_fs.py
+"""Aggregate facts from XBRL files into a single CSV."""
 
 from pathlib import Path
 import os
 from arelle_tools import extract_xbrl_from_zips, parse_xbrl
-import shutil, csv
+import shutil
+import csv
+
 
 def main() -> None:
-    # 出力先は CWD を既定。EDINET_OUTPUT_DIR があればそれを優先。
+    """Extract XBRL archives and generate a consolidated CSV."""
+    # Use the current working directory by default; prefer EDINET_OUTPUT_DIR if set.
     outputs = Path(os.getenv("EDINET_OUTPUT_DIR", Path.cwd() / "outputs")).resolve()
     extracted = outputs / "extracted"
     merged_csv = outputs / "all_facts.csv"
 
-    # 作業ディレクトリを初期化
+    # Initialize the working directory.
     if extracted.exists():
         shutil.rmtree(extracted)
     extracted.mkdir(parents=True, exist_ok=True)
 
-    # zip を展開してパス辞書取得
+    # Extract ZIP archives and gather XBRL paths.
     xbrl_paths = extract_xbrl_from_zips(outputs, extracted)
 
     aggregated: list[
         tuple[str, str, str, str | None, str | None, str | None, str | None, str | None]
     ] = []
 
-    print("✅ 解析開始:")
+    print("✅ Start parsing:")
     for zip_name, info in xbrl_paths.items():
         xbrl_path = Path(info["xbrl_path"])
         meta, facts = parse_xbrl(xbrl_path)
 
-        print(f"📁 {zip_name} 会社名:{meta['company_name']}  売上高:{meta['netsales']}")
+        print(f"📁 {zip_name} Company:{meta['company_name']}  Net sales:{meta['netsales']}")
 
         aggregated.extend(facts)
 
-    # ---------- まとめて CSV 出力 ----------
+    # ---------- Write aggregated facts to CSV ----------
     merged_csv.parent.mkdir(exist_ok=True, parents=True)
     with merged_csv.open("w", newline="", encoding="utf-8-sig") as f:
         writer = csv.writer(f)
-        writer.writerow([
-            "日本語ラベル", "英語ラベル", "値",
-            "contextID", "期首", "期末", "時点(期末)", "decimals"
-        ])
+        writer.writerow(
+            [
+                "日本語ラベル",
+                "英語ラベル",
+                "値",
+                "contextID",
+                "期首",
+                "期末",
+                "時点(期末)",
+                "decimals",
+            ]
+        )
         writer.writerows(aggregated)
 
-    print(f"\n📦 全 Fact を 1 つの CSV に保存しました → {merged_csv}")
+    print(f"\n📦 Saved all facts to a single CSV → {merged_csv}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/outputs.py
+++ b/src/outputs.py
@@ -1,37 +1,40 @@
-# src/outputs.py
+"""Aggregate converted CSV outputs into a single Excel file."""
 
 import os
 from pathlib import Path
 import zipfile
 import pandas as pd
 
+
 def aggregate_outputs(
     output_dir: str,
     result_path: str,
-    sheet_name: str = "data"
+    sheet_name: str = "data",
 ):
-    # 全 ZIP を探索
+    """Collect jpcrp CSV files from ZIP archives and merge into Excel."""
+    # Scan all ZIP files in the output directory.
     dfs = []
     for fname in os.listdir(output_dir):
         if not fname.lower().endswith(".zip"):
             continue
         zip_path = os.path.join(output_dir, fname)
-        # ZIP 名から年度ラベルを抽出（拡張子なし）
+        # Derive the year label from the ZIP name.
         label = os.path.splitext(fname)[0]
 
         with zipfile.ZipFile(zip_path, "r") as z:
-            # XBRL_TO_CSV フォルダ内の jpcrp*.csv をすべて読み込む
+            # Read all jpcrp*.csv files under XBRL_TO_CSV.
             for member in z.namelist():
                 if member.startswith("XBRL_TO_CSV/jpcrp") and member.endswith(".csv"):
                     with z.open(member) as f:
-                        # UTF-16LE + タブ区切り
+                        # UTF-16LE with tab separation.
                         df = pd.read_csv(f, sep="\t", encoding="utf-16")
-                        # 左端に「年度」列を追加
+                        # Insert a "年度" column at the start.
                         df.insert(0, "年度", label)
-                        # フィルタ処理
+                        # Filter for consolidated current period values.
                         valid_periods = ["当期", "当期末"]
                         df = df[
-                            df["相対年度"].isin(valid_periods) & (df["連結・個別"] == "連結")
+                            df["相対年度"].isin(valid_periods)
+                            & (df["連結・個別"] == "連結")
                         ]
                         if not df.empty:
                             dfs.append(df)
@@ -40,20 +43,24 @@ def aggregate_outputs(
         print("No jpcrp CSV files found.")
         return
 
-    # ヘッダーは全ファイル同一なのでそのまま concat
+    # Headers are identical across files, so simply concatenate.
     result_df = pd.concat(dfs, ignore_index=True)
 
-    # Excel に書き出し
+    # Write to Excel.
     with pd.ExcelWriter(result_path, engine="openpyxl") as writer:
         result_df.to_excel(writer, sheet_name=sheet_name, index=False)
 
     print(f"Written {len(result_df)} rows to {result_path} (sheet: {sheet_name})")
 
+
 def main() -> None:
+    """Entry point for command-line execution."""
     outdir = Path(os.getenv("EDINET_OUTPUT_DIR", Path.cwd() / "outputs")).resolve()
     outdir.mkdir(parents=True, exist_ok=True)
     resfile = outdir / "result.xlsx"
     aggregate_outputs(str(outdir), str(resfile))
 
+
 if __name__ == "__main__":
     main()
+

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -1,9 +1,18 @@
-# src/preflight.py
+"""Simple environment check for required dependencies."""
 
-import sys, inspect
+import sys
+import inspect
+
 print("Python:", sys.version)
-import arelle; print("arelle:", inspect.getfile(arelle))
-from lxml import etree; print("lxml:", etree.LIBXML_VERSION)
-import regex; print("regex:", regex.__version__)
-import PIL, importlib; importlib.import_module("PIL._imaging"); print("pillow OK")
+import arelle
+print("arelle:", inspect.getfile(arelle))
+from lxml import etree
+print("lxml:", etree.LIBXML_VERSION)
+import regex
+print("regex:", regex.__version__)
+import PIL
+import importlib
+importlib.import_module("PIL._imaging")
+print("pillow OK")
 print("[OK] preflight passed")
+

--- a/tests/test_edinet_tools.py
+++ b/tests/test_edinet_tools.py
@@ -1,11 +1,11 @@
-# tests/test_edinet_tools.py
+"""Tests for the edinet_tools module."""
 
 import os
 import sys
 import pytest
 
-# Ensure src directory is on path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+# Ensure src directory is on path.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from edinet_tools import filter_by_codes
 
@@ -24,3 +24,4 @@ def test_filter_by_list_codes():
 def test_filter_by_string_codes():
     result = filter_by_codes(sample_docs, edinet_codes="E00001", doc_type_codes="130")
     assert result == [sample_docs[2]]
+


### PR DESCRIPTION
## Summary
- standardize docstrings and inline comments across modules
- translate scripts and tests to consistent English style

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c3144ee08327839a1ebde6a0c28f